### PR TITLE
Disable .ping

### DIFF
--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,6 +1,6 @@
 exports.names = ['.ping'];
 exports.hidden = true;
-exports.enabled = true;
+exports.enabled = false;
 exports.matchStart = false;
 exports.handler = function (data) {
     var rand = Math.random();


### PR DESCRIPTION
People are spamming this in the chat as a substitute for being active in the room. Several mods have been telling them to stop using it, including Chupa and Margo and no one listens. I think disabling it is an appropriate solution.
